### PR TITLE
Fix macOS build and runtime issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts
+obj/
+mapfab

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ run: mapfab
 	./mapfab
 
 define compile
-@echo -e '\033[32mCXX $@\033[0m'
+@printf '\033[32mCXX $@\033[0m\n'
 $(CXX) $(CXXFLAGS) -c -o $@ $<
 endef
 
 define deps
-@echo -e '\033[32mDEPS $@\033[0m'
+@printf '\033[32mDEPS $@\033[0m\n'
 $(CXX) $(CXXFLAGS) -MM -MP -MT '\
 $(patsubst $(SRCDIR)/%,$(OBJDIR)/%,$(<:.cpp=.o)) \
 $(patsubst $(SRCDIR)/%,$(OBJDIR)/%,$(<:.cpp=.d))\
@@ -39,6 +39,13 @@ ifeq ($(ARCH),MINGW_GTK3)
 override WXCONFIG:=wx-config-gtk3
 endif
 
+# Detect compiler for error limit flag
+ifeq ($(shell $(CXX) --version 2>&1 | grep -q clang && echo clang),clang)
+  ERROR_LIMIT := -ferror-limit=3
+else
+  ERROR_LIMIT := -fmax-errors=3
+endif
+
 override CXXFLAGS+= \
   `$(WXCONFIG) --cxxflags` \
   -std=gnu++20 \
@@ -47,7 +54,7 @@ override CXXFLAGS+= \
   -Wno-unused-parameter \
   -Wno-narrowing \
   -Wno-missing-field-initializers \
-  -fmax-errors=3 \
+  $(ERROR_LIMIT) \
   -ftemplate-depth=100 \
   -pipe \
   -g \

--- a/src/grid_box.cpp
+++ b/src/grid_box.cpp
@@ -1,5 +1,7 @@
 #include "grid_box.hpp"
 
+#include <sstream>
+
 #include <wx/dcbuffer.h>
 #include <wx/graphics.h>
 #include <wx/dcgraph.h>
@@ -35,6 +37,8 @@ void grid_box_t::on_paint(wxPaintEvent& event)
 
 #ifdef __WXMSW__
     wxGraphicsRenderer* renderer = wxGraphicsRenderer::GetDirect2DRenderer();
+#elif defined(__WXOSX__)
+    wxGraphicsRenderer* renderer = wxGraphicsRenderer::GetDefaultRenderer();
 #else
     wxGraphicsRenderer* renderer = wxGraphicsRenderer::GetCairoRenderer();
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,11 +166,13 @@ private:
     }
 };
  
+inline wxDataFormat tiles_format() { return wxDataFormat("tiles"); }
+
 class clip_data_t : public wxDataObjectSimple
 {
 public:
     explicit clip_data_t(tile_copy_t const& cp = {}) 
-    : wxDataObjectSimple("tiles")
+    : wxDataObjectSimple(tiles_format())
     , data(cp.to_vec())
     {}
 
@@ -422,7 +424,7 @@ private:
         {
             if(wxTheClipboard->Open())
             {
-                if(wxTheClipboard->IsSupported("tiles"))
+                if(wxTheClipboard->IsSupported(tiles_format()))
                 {
                     clip_data_t data;
                     wxTheClipboard->GetData(data);
@@ -462,7 +464,7 @@ private:
         {
             if(wxTheClipboard->Open())
             {
-                if(wxTheClipboard->IsSupported("tiles"))
+                if(wxTheClipboard->IsSupported(tiles_format()))
                 {
                     clip_data_t data;
                     wxTheClipboard->GetData(data);


### PR DESCRIPTION
This PR fixes several issues that prevented building and running mapfab on macOS:

**Makefile changes:**
- Replace `echo -e` with `printf` for POSIX compatibility (macOS uses BSD echo)
- Detect clang vs gcc to use appropriate error limit flag (`-ferror-limit` vs `-fmax-errors`)

**Code fixes:**
- Add missing `#include <sstream>` in grid_box.cpp
- Use default wxGraphicsRenderer on macOS (`__WXOSX__`)
- Fix wxDataFormat usage for clipboard operations (macOS requires persistent format object)

**Other:**
- Add .gitignore for build artifacts

Tested on macOS with wxWidgets installed via Homebrew.